### PR TITLE
refactor : Character 모델 테스트코드 수정

### DIFF
--- a/src/test/java/model/CharacterTest.java
+++ b/src/test/java/model/CharacterTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class CharacterTest {
 
@@ -18,8 +17,7 @@ class CharacterTest {
 
 	@DisplayName("입력받는 글자가 영문자가 아닌 경우 에러를 반환한다.")
 	@ParameterizedTest
-	@CsvSource(value = {"1","!","?",">"})
-	@NullAndEmptySource
+	@CsvSource(value = {"1", "!", "?", ">"})
 	void validationOnlyEnglishTest(char character) {
 		assertThatThrownBy(
 			() -> new Character(character)


### PR DESCRIPTION
* 입력값 검증 테스트코드의 @NullAndEmptySource 어토네이션을 제거함.
 - 해당 객체는 char 타입을 주입받아 생성되는데 @NullAndEmptySource 는 char 타입을 지원하지 않음.
 - 테스트를 하고 지워야했던 코드가 삭제되지않고 반영된 것으로 보여서 정정처리함.